### PR TITLE
Add --new-years-message option to CLI

### DIFF
--- a/tridentine_calendar/cli.py
+++ b/tridentine_calendar/cli.py
@@ -2,7 +2,9 @@
 
 import argparse
 import os
+import subprocess
 import sys
+import tempfile
 
 from .tridentine_calendar import LiturgicalCalendar
 
@@ -62,12 +64,45 @@ def parse_args(args):
             'can be found.'
         ),
     )
+    parser.add_argument(
+        '--new-years-message',
+        action='store_true',
+        default=False,
+        help='Whether to add a custom message to the first day of the liturgical year.',
+    )
 
     return parser.parse_args(args)
 
 
+def get_message_from_editor():
+    """Open the user's editor to get a message.
+
+    Returns:
+        str: The message written by the user.
+
+    """
+    editor = os.environ.get('EDITOR', 'vi')
+    with tempfile.NamedTemporaryFile(suffix='.txt', delete=False) as tf:
+        tf_path = tf.name
+
+    try:
+        subprocess.run([editor, tf_path], check=True)
+        with open(tf_path, 'r') as f:
+            message = f.read().strip()
+    finally:
+        os.remove(tf_path)
+
+    return message
+
+
 def _main(args):
-    liturgical_calendar = LiturgicalCalendar(args.years, args.reuse_uids_from)
+    new_years_message = None
+    if getattr(args, 'new_years_message', False):
+        new_years_message = get_message_from_editor()
+
+    liturgical_calendar = LiturgicalCalendar(
+        args.years, args.reuse_uids_from, new_years_message
+    )
     if os.path.isfile(args.output) and not args.overwrite_existing:
         liturgical_calendar.extend_existing_ical(args.output, args.use_html_formatting)
         if 'remove_year' in args and args.remove_year is not None:

--- a/tridentine_calendar/tests/test_cli.py
+++ b/tridentine_calendar/tests/test_cli.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from ..cli import _main
 from ..cli import parse_args
@@ -21,6 +22,12 @@ class TestParseArgs(unittest.TestCase):
         self.assertEqual(args.years, [2000, 2010])
         self.assertFalse(args.overwrite_existing)
 
+    def test_parse_args_new_years_message(self):
+        args = parse_args(['--output', 'foo', '--new-years-message', '2000'])
+        self.assertEqual(args.output, 'foo')
+        self.assertEqual(args.years, [2000])
+        self.assertTrue(args.new_years_message)
+
     def test_parse_args_help(self):
         with self.assertRaises(SystemExit):
             parse_args(['-h'])
@@ -38,6 +45,21 @@ class TestMain(unittest.TestCase):
                 reuse_uids_from=None,
             )
             _main(args)
+
+    @patch('tridentine_calendar.cli.get_message_from_editor')
+    def test_main_new_years_message(self, mock_get_message):
+        mock_get_message.return_value = 'Custom message'
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            args = argparse.Namespace(
+                output=os.path.join(tmp_dir, 'foo'),
+                years=[2018],
+                overwrite_existing=False,
+                use_html_formatting=False,
+                reuse_uids_from=None,
+                new_years_message=True,
+            )
+            _main(args)
+            mock_get_message.assert_called_once()
 
     def test_main_existing_calendar(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tridentine_calendar/tests/test_tridentine_calendar.py
+++ b/tridentine_calendar/tests/test_tridentine_calendar.py
@@ -247,6 +247,15 @@ class TestLiturgicalCalendarEvent(unittest.TestCase):
         description = event.generate_description(html_formatting=False)
         self.assertTrue(description.startswith(expected_description))
 
+    def test_generate_description_with_custom_description(self):
+        event = LiturgicalCalendarEvent(
+            dt.date(2018, 12, 2),
+            'First Sunday of Advent',
+            custom_description='This is a custom message.',
+        )
+        description = event.generate_description()
+        self.assertTrue(description.startswith('This is a custom message.\n\n'))
+
     def test_is_fixed(self):
         event = LiturgicalCalendarEvent(
             dt.date(2018, 12, 8),
@@ -274,6 +283,16 @@ class TestLiturgicalYearSmoke(unittest.TestCase):
 
     def test_liturgical_year(self):
         self.assertIsNotNone(LiturgicalYear(2018))
+
+    def test_liturgical_year_with_message(self):
+        message = 'Happy New Liturgical Year!'
+        litcal = LiturgicalYear(2019, new_years_message=message)
+        start_date = litcal.liturgical_year_start
+        events = litcal[start_date]
+        self.assertTrue(any(e.name == '» New Liturgical Year' for e in events))
+        new_year_event = [e for e in events if e.name == '» New Liturgical Year'][0]
+        self.assertEqual(new_year_event.custom_description, message)
+        self.assertEqual(new_year_event.rank, 4)
 
 
 class TestLiturgicalYearSundayDates(unittest.TestCase):

--- a/tridentine_calendar/tridentine_calendar.py
+++ b/tridentine_calendar/tridentine_calendar.py
@@ -209,6 +209,7 @@ class LiturgicalCalendarEvent:
         holy_day=False,
         addition=False,
         is_vigil=False,
+        custom_description=None,
         season=None,
     ):
         """Instantiate a `LiturgicalCalendarEvent`.
@@ -253,6 +254,7 @@ class LiturgicalCalendarEvent:
         self.addition = addition
         self.holy_day = holy_day
         self.is_vigil = is_vigil
+        self.custom_description = custom_description
         self.season = LiturgicalSeason.from_date(date)
 
         if color is None:
@@ -379,13 +381,16 @@ class LiturgicalCalendarEvent:
 
         """
         description = ''
+        if self.custom_description:
+            description += self.custom_description + '\n\n'
+
         if self.holy_day:
             description += f'{self.full_name()} is a Holy Day of Obligation.'
 
         if description != '' and description[-1] == '.':
             description += ' '
 
-        if self.liturgical_event and self.rank < 4:
+        if self.liturgical_event and self.rank is not None and self.rank < 4:
             if self.holy_day:
                 name = 'Today'
             elif not ranking_feast:
@@ -459,7 +464,7 @@ class LiturgicalCalendarEvent:
 class LiturgicalYear:
     """A liturgical year following the 1962 Roman Catholic rubrics."""
 
-    def __init__(self, year, uid_map=None):
+    def __init__(self, year, uid_map=None, new_years_message=None):
         """Instantiate a `LiturgicalYear` object.
 
         Note that the liturgical year starts before the year given on the first Sunday
@@ -558,6 +563,17 @@ class LiturgicalYear:
                     if elem.get('class') != 1:
                         event = LiturgicalCalendarEvent.from_json(date, elem)
                         self.calendar[date].append(event)
+
+            if date == self.liturgical_year_start and new_years_message:
+                event = LiturgicalCalendarEvent(
+                    date,
+                    name='» New Liturgical Year',
+                    liturgical_event=False,
+                    rank=4,
+                    custom_description=new_years_message,
+                )
+                self.calendar[date].append(event)
+
             self.calendar[date] = sorted(self.calendar[date], key=_feast_sort_key)
 
     def __getitem__(self, key):
@@ -601,7 +617,7 @@ class LiturgicalYear:
                             outranking_feast.full_name(capitalize=False),
                         )
 
-                if not elem.liturgical_event:
+                if not elem.liturgical_event and not elem.name.startswith('»'):
                     ics_name = '» ' + ics_name
 
                 feast_description = elem.generate_description(
@@ -653,7 +669,7 @@ def _feast_sort_key(feast):
 class LiturgicalCalendar:
     """A liturgical calendar following the 1962 Roman Catholic rubrics."""
 
-    def __init__(self, years, reuse_uids_from=None):
+    def __init__(self, years, reuse_uids_from=None, new_years_message=None):
         """Instantiate a `LiturgicalCalendar` object for the given year or years.
 
         Args:
@@ -675,7 +691,9 @@ class LiturgicalCalendar:
         if isinstance(years, int):
             years = [years]
         for year in years:
-            self.liturgical_years[year] = LiturgicalYear(year, self.uid_map)
+            self.liturgical_years[year] = LiturgicalYear(
+                year, self.uid_map, new_years_message
+            )
 
     def __getitem__(self, key):
         """Return the events for a given day.


### PR DESCRIPTION
I have added a new `--new-years-message` option to the `tridentine_calendar` CLI. This option allows users to provide a custom message for the start of the liturgical year via a text editor.

Changes made:
-   **`tridentine_calendar/tridentine_calendar.py`**:
    -   Added `custom_description` parameter to `LiturgicalCalendarEvent.__init__`.
    -   Updated `LiturgicalCalendarEvent.generate_description` to prepend `custom_description` to the output.
    -   Modified `LiturgicalYear.__init__` to accept `new_years_message` and add a "» New Liturgical Year" event on the first day of the liturgical year.
    -   Ensured the new event has a `rank` of 4 to avoid comparison errors during sorting.
    -   Updated `to_ical` logic to prevent double-prefixing of the "»" character for non-liturgical events.
-   **`tridentine_calendar/cli.py`**:
    -   Added the `--new-years-message` flag to the command-line arguments.
    -   Implemented `get_message_from_editor` to open the user's preferred editor (defaulting to `vi`) using a temporary file.
    -   Updated `_main` to integrate the editor call and pass the resulting message to the `LiturgicalCalendar` constructor.
-   **Tests**:
    -   Added unit tests in `test_tridentine_calendar.py` for the new event and custom description logic.
    -   Added tests in `test_cli.py` for the new flag and editor integration, using mocking to simulate the subprocess.

All 83 tests passed successfully.

---
*PR created automatically by Jules for task [4448429030528775351](https://jules.google.com/task/4448429030528775351) started by @joe-antognini*