### PR TITLE
Remove redundant 'pape' suffix from French feast names

### DIFF
--- a/tridentine_calendar/i18n/fr/feasts_seasons.csv
+++ b/tridentine_calendar/i18n/fr/feasts_seasons.csv
@@ -70,29 +70,29 @@ Pentecost Monday,Lundi de la Pentecôte
 Pentecost Tuesday,Mardi de la Pentecôte
 Peter's Pence,Denier de Saint-Pierre
 Plough Monday,Plough Monday
-Pope Anicetus,"st Anicet, pape"
-Pope Callistus I,"st Calixte I, pape"
-Pope Celestine V,"st Célestin V, pape"
-Pope Clement I,"st Clément I, pape"
-Pope Cornelius & St. Cyprian,"st Corneille et st Cyprien, pape"
-Pope Damasus I,"st Damase I, pape"
-Pope Evaristus,"st Évariste, pape"
-Pope Fabian & St. Sebastian,"st Fabien et st Sébastien, pape"
-Pope Felix I,"st Félix I, pape"
-Pope Gregory VII,"st Grégoire VII, pape"
-Pope Gregory the Great,"st Grégoire le Grand, pape"
-Pope Hyginus,"st Hygin, pape"
-Pope Leo the Great,"st Léon le Grand, pape"
-Pope Linus,"st Lin, pape"
-Pope Marcellus I,"st Marcel Ier, pape"
-Pope Martin I,"st Martin I, pape"
-Pope Melchiades,"st Miltiade, pape"
-Pope Pius I,"st Pie I, pape"
-Pope Pius V,"st Pie V, pape"
-Pope Pius X,"st Pie X, pape"
-Pope Silverius,"st Silvère, pape"
-Pope Sylvester I,"st Sylvestre Ier, pape"
-Pope Zephyrinus,"st Zéphyrin, pape"
+Pope Anicetus,"st Anicet"
+Pope Callistus I,"st Calixte I"
+Pope Celestine V,"st Célestin V"
+Pope Clement I,"st Clément I"
+Pope Cornelius & St. Cyprian,"st Corneille et st Cyprien"
+Pope Damasus I,"st Damase I"
+Pope Evaristus,"st Évariste"
+Pope Fabian & St. Sebastian,"st Fabien et st Sébastien"
+Pope Felix I,"st Félix I"
+Pope Gregory VII,"st Grégoire VII"
+Pope Gregory the Great,"st Grégoire le Grand"
+Pope Hyginus,"st Hygin"
+Pope Leo the Great,"st Léon le Grand"
+Pope Linus,"st Lin"
+Pope Marcellus I,"st Marcel Ier"
+Pope Martin I,"st Martin I"
+Pope Melchiades,"st Miltiade"
+Pope Pius I,"st Pie I"
+Pope Pius V,"st Pie V"
+Pope Pius X,"st Pie X"
+Pope Silverius,"st Silvère"
+Pope Sylvester I,"st Sylvestre Ier"
+Pope Zephyrinus,"st Zéphyrin"
 Precious Blood,Précieux Sang
 Precious Blood of Jesus,Précieux Sang de Jésus
 Quasimodo Sunday,Dimanche de Quasimodo
@@ -123,7 +123,7 @@ SS. Philip & James,sts Philip et James
 SS. Primus & Felician,sts Prime et Félicien
 SS. Protus & Hyacinth,sts Prote et Hyacinthe
 SS. Simon & Jude,sts Simon et Jude
-SS. Soter & Caius,"sts Sôter et Caïus, papes"
+SS. Soter & Caius,"sts Sôter et Caïus"
 SS. Vincent & Anastasius,sts Vincent et Anastase
 "SS. Vitus, Modestus, & Crescentia","sts Vitus, Modestus, et Crescentia"
 Sacred Heart,Sacré-Cœur
@@ -441,7 +441,7 @@ St. Raphael the Archangel,st Raphaël Archange
 St. Martin of Tours,st Martin de Tours
 St. Clement I,st Clément Ier
 St. John the Evangelist,st Jean l'Évangéliste
-St. Sylvester I,"st Sylvestre Ier, pape"
+St. Sylvester I,"st Sylvestre Ier"
 St Raymond of Peñafort,st Raymond de Peñafort
 St John of Matha,st Jean de Matha
 St Cyril of Alexandria,st Cyrille d'Alexandrie
@@ -483,7 +483,7 @@ The Seven Holy Brothers and Sts. Rufina and Secunda,Les Sept saints Frères et l
 St. Jean's Eve,Vigile de la Fête de st Jean
 "SS. Vitus, Modestus & Crescentia","sts Vite, Modeste, et Crescence"
 SS. Gervasius & Protasius,Gervais et Protais
-"SS. Nazarius, Celsus, Victor I & Innocent I","sts Nazaire et Celse, Victor Ier, Innocent Ier, papes"
+"SS. Nazarius, Celsus, Victor I & Innocent I","sts Nazaire et Celse, Victor Ier, Innocent Ier"
 SS. Tiburtius & Susanna,st Tiburce et ste Suzanne
 St. Placidus,st Placide
 St. Francis Borgia,st François Borgia

--- a/tridentine_calendar/tests/test_issue_pape_redundancy.py
+++ b/tridentine_calendar/tests/test_issue_pape_redundancy.py
@@ -1,0 +1,27 @@
+from tridentine_calendar.i18n import Translator
+
+
+def test_fr_pape_redundancy():
+    translator = Translator(lang='fr')
+
+    # Test case provided by the user
+    name = "Pope Melchiades"
+    titles = ["Pope", "Martyr"]
+    full_name = translator.format_feast_full_name(name, 3, titles)
+    # The current (buggy) output is "la fête de st Miltiade, pape (pape, martyr)"
+    # The expected output is "la fête de st Miltiade (pape, martyr)"
+    assert "pape (" in full_name or not full_name.endswith(", pape")
+    assert ", pape (" not in full_name
+    assert full_name == "la fête de st Miltiade (pape, martyr)"
+
+
+def test_fr_papes_redundancy():
+    translator = Translator(lang='fr')
+
+    name = "SS. Soter & Caius"
+    titles = ["Pope", "Martyr"]
+    full_name = translator.format_feast_full_name(name, 3, titles)
+    # Current: "la fête de sts Sôter et Caïus, papes (pape, martyr)"
+    # Expected: "la fête de sts Sôter et Caïus (pape, martyr)"
+    assert ", papes (" not in full_name
+    assert full_name == "la fête de sts Sôter et Caïus (pape, martyr)"


### PR DESCRIPTION
This change removes the hardcoded ', pape' and ', papes' suffixes from the French translations of saint names in the liturgical calendar. These suffixes caused redundancy in descriptions where the title 'pape' was already being appended by the liturgical event formatting logic.

Specifically:
- Updated `tridentine_calendar/i18n/fr/feasts_seasons.csv` to strip the redundant suffixes.
- Added `tridentine_calendar/tests/test_issue_pape_redundancy.py` to verify the fix and prevent regressions.

---
*PR created automatically by Jules for task [599535031435429065](https://jules.google.com/task/599535031435429065) started by @joe-antognini*