### PR TITLE
Fix French grammatical agreement for plural feast names

### DIFF
--- a/tridentine_calendar/i18n/translator.py
+++ b/tridentine_calendar/i18n/translator.py
@@ -250,6 +250,12 @@ class Translator:
             return self.weekdays[text]
         return self.translations.get(text, text)
 
+    def _is_plural(self, name):
+        if self.lang != 'fr':
+            return False
+        plural_prefixes = ('Les ', 'les ', 'sts ', 'stes ')
+        return name.lstrip('» ').lstrip('› ').startswith(plural_prefixes)
+
     def get_ordinal(self, n):
         return self.ordinals.get(n, str(n))
 
@@ -352,7 +358,12 @@ class Translator:
             rank_str = self.translate(str(rank))
         else:
             rank_str = rank * 'I'
-        return self.templates['class_feria'].format(
+
+        template = self.templates['class_feria']
+        if self._is_plural(name):
+            template = template.replace(' est ', ' sont ')
+
+        return template.format(
             name=name, rank=rank_str, type=type_str)
 
     def format_color(self, color):
@@ -365,19 +376,29 @@ class Translator:
 
     def format_outranking(
             self, feast, outranking_feast, is_fixed_outranked_by_fixed):
-        template = (
+        template_key = (
             'outranking' if is_fixed_outranked_by_fixed
             else 'outranking_this_year')
-        return self.templates[template].format(
+        template = self.templates[template_key]
+        if self._is_plural(feast):
+            template = template.replace(' est ', ' sont ')
+            template = template.replace(' omise.', ' omises.')
+        return template.format(
             feast=make_initial__the__lowercase(feast),
             outranking_feast=outranking_feast,
         )
 
     def format_holy_day(self, name):
-        return self.templates['holy_day'].format(name=name)
+        template = self.templates['holy_day']
+        if self._is_plural(name):
+            template = template.replace(' est ', ' sont ')
+        return template.format(name=name)
 
     def format_no_special_liturgy(self, name):
-        return self.templates['no_special_liturgy'].format(name=name)
+        template = self.templates['no_special_liturgy']
+        if self._is_plural(name):
+            template = template.replace(' n\'a pas ', ' n\'ont pas ')
+        return template.format(name=name)
 
     def format_commemoration(self):
         return self.templates['today_is_commemoration']

--- a/tridentine_calendar/tests/test_fr_localization.py
+++ b/tridentine_calendar/tests/test_fr_localization.py
@@ -52,3 +52,25 @@ def test_fr_liturgical_calendar_output():
     # Since it is a holy day of obligation, "Aujourd'hui" is used instead of
     # the full name in the class_feria string
     assert "Aujourd'hui est une fête de Ire classe." in description
+
+
+def test_fr_plural_agreement():
+    translator = Translator(lang='fr')
+
+    # Test "Les"
+    assert "sont" in translator.format_class_feria("Les martyrs", 2, True)
+    assert "n'ont pas" in translator.format_no_special_liturgy("Les Grandes Ô")
+
+    # Test "sts"
+    assert "sont" in translator.format_class_feria("sts Abdon et Sennen", 3, True)
+
+    # Test "stes"
+    assert "sont" in translator.format_class_feria("stes Perpétue et Félicité", 3, True)
+
+    # Test outranking plural
+    outranking = translator.format_outranking("Les martyrs", "Une fête", True)
+    assert "sont omises" in outranking
+
+    # Test holy day plural
+    holy = translator.format_holy_day("Les Grandes Ô")
+    assert "sont" in holy


### PR DESCRIPTION
This change fixes a grammatical bug in French where plural feasts like "Les Grandes Ô" (O Antiphons) or "Les martyrs canadiens" were described using singular verb forms (e.g., "n'a pas", "est").

A new private helper method `_is_plural` was added to the `Translator` class to detect French plural subjects by their prefixes. The formatting methods `format_no_special_liturgy`, `format_class_feria`, `format_holy_day`, and `format_outranking` now use this check to apply correct plural verb agreement in French. A new test case `test_fr_plural_agreement` was added to `tridentine_calendar/tests/test_fr_localization.py` to ensure ongoing correctness.

---
*PR created automatically by Jules for task [17604007225860169450](https://jules.google.com/task/17604007225860169450) started by @joe-antognini*