### PR TITLE
Capitalize French saint abbreviations

### DIFF
--- a/tridentine_calendar/i18n/fr/feasts_seasons.csv
+++ b/tridentine_calendar/i18n/fr/feasts_seasons.csv
@@ -7,7 +7,7 @@ Ascension,Ascension
 Ash Wednesday,Mercredi des Cendres
 Baptism of Christ,Baptême du Seigneur
 Basilica of St. John Lateran,Dédicace de l'archibasilique du Latran
-Basilicas of SS. Peter & Paul,Dédicace des basiliques de st Pierre et st Paul
+Basilicas of SS. Peter & Paul,Dédicace des basiliques de St Pierre et St Paul
 Canadian Martyrs,Les martyrs canadiens
 Candlemas,La Chandeleur
 Cantate Sunday,Quatrième dimanche de Pâques
@@ -17,7 +17,7 @@ Christ the King,Le Christ-Roi
 Christmas,Noël
 Christmas Eve,Vigile de Noël
 Church of St. Mary of the Snow,Notre-Dame des Neiges
-Conversion of St. Paul,Conversion de st Paul
+Conversion of St. Paul,Conversion de St Paul
 Corpus Christi,La Fête-Dieu
 Easter,Pâques
 Easter Friday,Vendredi de Pâques
@@ -35,7 +35,7 @@ Golden Nights,Les Grandes Ô
 Good Friday,Vendredi saint
 Halloween,Halloween
 Hallowmas,Toussaint
-Holy Family,ste Famille
+Holy Family,Ste Famille
 Holy Name,saint Nom
 Holy Name of Jesus,saint Nom de Jésus
 Holy Saturday,Samedi saint
@@ -70,275 +70,275 @@ Pentecost Monday,Lundi de la Pentecôte
 Pentecost Tuesday,Mardi de la Pentecôte
 Peter's Pence,Denier de Saint-Pierre
 Plough Monday,Plough Monday
-Pope Anicetus,"st Anicet"
-Pope Callistus I,"st Calixte I"
-Pope Celestine V,"st Célestin V"
-Pope Clement I,"st Clément I"
-Pope Cornelius & St. Cyprian,"st Corneille et st Cyprien"
-Pope Damasus I,"st Damase I"
-Pope Evaristus,"st Évariste"
-Pope Fabian & St. Sebastian,"st Fabien et st Sébastien"
-Pope Felix I,"st Félix I"
-Pope Gregory VII,"st Grégoire VII"
-Pope Gregory the Great,"st Grégoire le Grand"
-Pope Hyginus,"st Hygin"
-Pope Leo the Great,"st Léon le Grand"
-Pope Linus,"st Lin"
-Pope Marcellus I,"st Marcel Ier"
-Pope Martin I,"st Martin I"
-Pope Melchiades,"st Miltiade"
-Pope Pius I,"st Pie I"
-Pope Pius V,"st Pie V"
-Pope Pius X,"st Pie X"
-Pope Silverius,"st Silvère"
-Pope Sylvester I,"st Sylvestre Ier"
-Pope Zephyrinus,"st Zéphyrin"
+Pope Anicetus,"St Anicet"
+Pope Callistus I,"St Calixte I"
+Pope Celestine V,"St Célestin V"
+Pope Clement I,"St Clément I"
+Pope Cornelius & St. Cyprian,"St Corneille et St Cyprien"
+Pope Damasus I,"St Damase I"
+Pope Evaristus,"St Évariste"
+Pope Fabian & St. Sebastian,"St Fabien et St Sébastien"
+Pope Felix I,"St Félix I"
+Pope Gregory VII,"St Grégoire VII"
+Pope Gregory the Great,"St Grégoire le Grand"
+Pope Hyginus,"St Hygin"
+Pope Leo the Great,"St Léon le Grand"
+Pope Linus,"St Lin"
+Pope Marcellus I,"St Marcel Ier"
+Pope Martin I,"St Martin I"
+Pope Melchiades,"St Miltiade"
+Pope Pius I,"St Pie I"
+Pope Pius V,"St Pie V"
+Pope Pius X,"St Pie X"
+Pope Silverius,"St Silvère"
+Pope Sylvester I,"St Sylvestre Ier"
+Pope Zephyrinus,"St Zéphyrin"
 Precious Blood,Précieux Sang
 Precious Blood of Jesus,Précieux Sang de Jésus
 Quasimodo Sunday,Dimanche de Quasimodo
 Quinquagesima,Quinquagesima
 Roodmas,Fête de la Croix
-SS. Abdon & Sennen,sts Abdon et Sennen
-SS. Alexander & Companions,sts Alexander et Companions
-"SS. Basilides, Cyrinus, Nabor, & Nazarius","sts Basilides, Cyrinus, Nabor, et Nazarius"
-SS. Chrysanthus & Daria,sts Crisant et Daria
-SS. Cletus and Marcellinus,sts Clet et Marcellin
-SS. Cosmas & Damian,sts Côme et Damien
-SS. Cyprian & Justina,sts Cyprien et Justina
-"SS. Cyriacus, Largus, & Smaragdus","sts Cyriacus, Largus, et Smaragdus"
-SS. Cyril and Methodius,sts Cyrille et Méthode
-SS. Faustinus & Jovita,sts Faustinus et Jovita
-SS. Felix & Adauctus,sts Félix et Adauctus
-SS. Gervase & Protase,sts Gervase et Protase
-SS. Hippolytus & Cassian,sts Hippolyte et Cassien
-SS. John & Paul,sts Jean et Paul
-"SS. Marcellinus, Peter, & St. Erasmus","sts Marcellinus, Pierre, et st Erasmus"
-"SS. Marius, Martha, Audifax, & Abachum","sts Maris, Marthe, Audifax et Abacum"
-SS. Mark & Marcellian,sts Marc et Marcellianus
-"SS. Nazarius & Celsus, St. Victor I, St. Innocent I","sts Nazarius et Celsus, st Victor I, st Innocent I"
-"SS. Nereus, Achilleus, Domitilla, & Pancras","sts Nereus, Achilleus, Domitilla, et Pancras"
-SS. Perpetua and Felicitas,stes Perpétue et Félicité
-SS. Peter & Paul,sts Pierre et Paul
-SS. Philip & James,sts Philip et James
-SS. Primus & Felician,sts Prime et Félicien
-SS. Protus & Hyacinth,sts Prote et Hyacinthe
-SS. Simon & Jude,sts Simon et Jude
-SS. Soter & Caius,"sts Sôter et Caïus"
-SS. Vincent & Anastasius,sts Vincent et Anastase
-"SS. Vitus, Modestus, & Crescentia","sts Vitus, Modestus, et Crescentia"
+SS. Abdon & Sennen,Sts Abdon et Sennen
+SS. Alexander & Companions,Sts Alexander et Companions
+"SS. Basilides, Cyrinus, Nabor, & Nazarius","Sts Basilides, Cyrinus, Nabor, et Nazarius"
+SS. Chrysanthus & Daria,Sts Crisant et Daria
+SS. Cletus and Marcellinus,Sts Clet et Marcellin
+SS. Cosmas & Damian,Sts Côme et Damien
+SS. Cyprian & Justina,Sts Cyprien et Justina
+"SS. Cyriacus, Largus, & Smaragdus","Sts Cyriacus, Largus, et Smaragdus"
+SS. Cyril and Methodius,Sts Cyrille et Méthode
+SS. Faustinus & Jovita,Sts Faustinus et Jovita
+SS. Felix & Adauctus,Sts Félix et Adauctus
+SS. Gervase & Protase,Sts Gervase et Protase
+SS. Hippolytus & Cassian,Sts Hippolyte et Cassien
+SS. John & Paul,Sts Jean et Paul
+"SS. Marcellinus, Peter, & St. Erasmus","Sts Marcellinus, Pierre, et St Erasmus"
+"SS. Marius, Martha, Audifax, & Abachum","Sts Maris, Marthe, Audifax et Abacum"
+SS. Mark & Marcellian,Sts Marc et Marcellianus
+"SS. Nazarius & Celsus, St. Victor I, St. Innocent I","Sts Nazarius et Celsus, St Victor I, St Innocent I"
+"SS. Nereus, Achilleus, Domitilla, & Pancras","Sts Nereus, Achilleus, Domitilla, et Pancras"
+SS. Perpetua and Felicitas,Stes Perpétue et Félicité
+SS. Peter & Paul,Sts Pierre et Paul
+SS. Philip & James,Sts Philip et James
+SS. Primus & Felician,Sts Prime et Félicien
+SS. Protus & Hyacinth,Sts Prote et Hyacinthe
+SS. Simon & Jude,Sts Simon et Jude
+SS. Soter & Caius,"Sts Sôter et Caïus"
+SS. Vincent & Anastasius,Sts Vincent et Anastase
+"SS. Vitus, Modestus, & Crescentia","Sts Vitus, Modestus, et Crescentia"
 Sacred Heart,Sacré-Cœur
 Sacred Heart of Jesus,Sacré-Cœur de Jésus
 Septuagesima,Septuagesima
 Sexagesima,Sexagesima
 Shrove Monday,Shrove Monday
 Spy Wednesday,Mercredi saint
-St. Agapitus,st Agapit
-St. Agatha,ste Agathe
-St. Agnes,ste Agnès
+St. Agapitus,St Agapit
+St. Agatha,Ste Agathe
+St. Agnes,Ste Agnès
 St. Albert the Great,Albert le Grand
-St. Alexius,st Alexis
-St. Alphonsus Liguori,st Alphonse de Liguori
-St. Ambrose,st Ambrose
-St. Andrew,st André
-St. Andrew Avellino,st André Avellin
-St. Andrew Corsini,st André Corsini
-St. Angela Merici,ste Angèle Mérici
-St. Anne,ste Anne
-St. Anselm,st Anselme
-St. Anthony Mary Claret,st Antoine-Marie Claret
-St. Anthony Mary Zaccaria,st Antoine-Marie Zaccaria
-St. Anthony of Padua,st Antoine de Padoue
-St. Anthony the Great,st Antoine le Grand
-St. Antoninus,st Antoninus
-St. Apollinaris,st Apollinaire
-St. Athanasius,st Athanase
-St. Augustine,st Augustin
-St. Augustine of Canterbury,st Augustin de Cantorbéry
-St. Barbara,ste Barbe
-St. Barnabas,st Barnabé
-St. Bartholomew,st Barthélemy
-St. Basil the Great,st Basile le Grand
-St. Bede the Venerable,st Bede the Venerable
-St. Benedict,st Benoît
-St. Bernard,st Bernard
-St. Bernardine of Siena,st Bernardin de Sienne
-St. Bibiana,ste Bibiane
-St. Blaise,st Blaise
-St. Bonaventure,st Bonaventure
-St. Boniface,st Boniface
-St. Boniface of Tarsus,st Boniface de Tarse
-St. Bridget,ste Brigitte
-St. Brigid,ste Brigitte
-St. Bruno,st Bruno
-St. Cabrini,st Cabrini
-St. Cajetan,st Gaétan
-St. Camillus de Lellis,st Camille de Lellis
-St. Casimir,st Casimir
-St. Catherine of Alexandria,ste Catherine d'Alexandrie
-St. Catherine of Siena,ste Catherine de Sienne
-St. Cecilia,ste Cécile
-St. Charles Borromeo,st Charles Borromée
-St. Christina,ste Christine
-St. Clare,ste Claire
-St. Columba,st Columba
-St. Cyril of Alexandria,st Cyrille d'Alexandrie
-St. Cyril of Jerusalem,st Cyrille de Jérusalem
-St. Didacus,st Diego
-St. Dominic,st Dominique
-St. Dymphna,st Dymphna
-St. Edward,st Édouard
-St. Elizabeth,ste Élisabeth
-St. Elizabeth of Hungary,ste Élisabeth de Hongrie
-St. Ephrem,st Éphrem
-St. Eusebius,st Eusebius
-St. Eustace and Companions,st Eustache et ses compagnons
-St. Felix of Valois,st Félix de Valois
-St. Fidelis of Sigmaringen,st Fidèle de Sigmaringen
-St. Frances of Rome,ste Françoise Romaine
-St. Francis Borgi,st Francis Borgi
-St. Francis Caracciolo,st François Caracciolo
-St. Francis Xavier,st François Xavier
-St. Francis de Sales,st François de Sales
-St. Francis of Assisi,st François d'Assise
-St. Francis of Paula,st François de Paule
-St. Gabriel,st Gabriel
-St. Gabriel of Our Lady of Sorrows,st Gabriel de l'Addolorata
-St. George,st Georges
-St. Gerard Majella,st Gérard Majella
-St. Germaine Cousin,ste Germaine Cousin
-St. Gertrude,st Gertrude
-St. Giles,st Gilles
-St. Gorgonius,st Gorgon
-St. Gregory Barbarigo,st Grégoire Barbarigo
-St. Gregory Nazianzen,st Grégoire Nazianzen
-St. Gregory Thaumaturgus,st Grégoire Thaumaturgus
-St. Hedwig,ste Edwige
-St. Henry,st Henri
-St. Hermenegild,st Herménégilde
-St. Hilarion,st Hilarion
-St. Hilary,st Hilaire
-St. Hildegard of Bingen,ste Hildegarde de Bingen
-St. Hyacinth,st Hyacinthe
-St. Ignatius,st Ignatius
-St. Ignatius of Loyola,st Ignace de Loyola
-St. Irenaeus,st Irénée
-St. Isidore,st Isidore
-St. Isidore the Farmer,st Isidore the Farmer
-St. James the Greater,st Jacques le Majeur
-St. Jane Frances Fremiot de Chantal,ste Jeanne de Chantal
-St. Januarius,st Janvier
-St. Jerome,st Jérôme
-St. Jerome Emilian,st Jérôme Emilien
-St. Joachim,st Joachim
-St. Joan of Arc,ste Jeanne d'Arc
-St. John,st Jean
-St. John Baptist de la Salle,st Jean Baptist de la Salle
-St. John Bosco,st Jean Bosco
-St. John Cantius,st Jean Cantius
-St. John Capistrano,st Jean Capistrano
-St. John Chrysostom,st Jean Chrysostome
-St. John Damascene,st Jean Damascene
-St. John Eudes,st Jean Eudes
-St. John Gualbert,st Jean Gualbert
-St. John Leonardi,st Jean Leonardi
-St. John Mary Vianney,st Jean-Marie Vianney
-St. John of God,st Jean de Dieu
-St. John of Matha,st Jean de Matha
-St. John of St. Facundo,st Jean de San Facundo
-St. John of the Cross,st Jean de la Croix
+St. Alexius,St Alexis
+St. Alphonsus Liguori,St Alphonse de Liguori
+St. Ambrose,St Ambrose
+St. Andrew,St André
+St. Andrew Avellino,St André Avellin
+St. Andrew Corsini,St André Corsini
+St. Angela Merici,Ste Angèle Mérici
+St. Anne,Ste Anne
+St. Anselm,St Anselme
+St. Anthony Mary Claret,St Antoine-Marie Claret
+St. Anthony Mary Zaccaria,St Antoine-Marie Zaccaria
+St. Anthony of Padua,St Antoine de Padoue
+St. Anthony the Great,St Antoine le Grand
+St. Antoninus,St Antoninus
+St. Apollinaris,St Apollinaire
+St. Athanasius,St Athanase
+St. Augustine,St Augustin
+St. Augustine of Canterbury,St Augustin de Cantorbéry
+St. Barbara,Ste Barbe
+St. Barnabas,St Barnabé
+St. Bartholomew,St Barthélemy
+St. Basil the Great,St Basile le Grand
+St. Bede the Venerable,St Bede the Venerable
+St. Benedict,St Benoît
+St. Bernard,St Bernard
+St. Bernardine of Siena,St Bernardin de Sienne
+St. Bibiana,Ste Bibiane
+St. Blaise,St Blaise
+St. Bonaventure,St Bonaventure
+St. Boniface,St Boniface
+St. Boniface of Tarsus,St Boniface de Tarse
+St. Bridget,Ste Brigitte
+St. Brigid,Ste Brigitte
+St. Bruno,St Bruno
+St. Cabrini,St Cabrini
+St. Cajetan,St Gaétan
+St. Camillus de Lellis,St Camille de Lellis
+St. Casimir,St Casimir
+St. Catherine of Alexandria,Ste Catherine d'Alexandrie
+St. Catherine of Siena,Ste Catherine de Sienne
+St. Cecilia,Ste Cécile
+St. Charles Borromeo,St Charles Borromée
+St. Christina,Ste Christine
+St. Clare,Ste Claire
+St. Columba,St Columba
+St. Cyril of Alexandria,St Cyrille d'Alexandrie
+St. Cyril of Jerusalem,St Cyrille de Jérusalem
+St. Didacus,St Diego
+St. Dominic,St Dominique
+St. Dymphna,St Dymphna
+St. Edward,St Édouard
+St. Elizabeth,Ste Élisabeth
+St. Elizabeth of Hungary,Ste Élisabeth de Hongrie
+St. Ephrem,St Éphrem
+St. Eusebius,St Eusebius
+St. Eustace and Companions,St Eustache et ses compagnons
+St. Felix of Valois,St Félix de Valois
+St. Fidelis of Sigmaringen,St Fidèle de Sigmaringen
+St. Frances of Rome,Ste Françoise Romaine
+St. Francis Borgi,St Francis Borgi
+St. Francis Caracciolo,St François Caracciolo
+St. Francis Xavier,St François Xavier
+St. Francis de Sales,St François de Sales
+St. Francis of Assisi,St François d'Assise
+St. Francis of Paula,St François de Paule
+St. Gabriel,St Gabriel
+St. Gabriel of Our Lady of Sorrows,St Gabriel de l'Addolorata
+St. George,St Georges
+St. Gerard Majella,St Gérard Majella
+St. Germaine Cousin,Ste Germaine Cousin
+St. Gertrude,St Gertrude
+St. Giles,St Gilles
+St. Gorgonius,St Gorgon
+St. Gregory Barbarigo,St Grégoire Barbarigo
+St. Gregory Nazianzen,St Grégoire Nazianzen
+St. Gregory Thaumaturgus,St Grégoire Thaumaturgus
+St. Hedwig,Ste Edwige
+St. Henry,St Henri
+St. Hermenegild,St Herménégilde
+St. Hilarion,St Hilarion
+St. Hilary,St Hilaire
+St. Hildegard of Bingen,Ste Hildegarde de Bingen
+St. Hyacinth,St Hyacinthe
+St. Ignatius,St Ignatius
+St. Ignatius of Loyola,St Ignace de Loyola
+St. Irenaeus,St Irénée
+St. Isidore,St Isidore
+St. Isidore the Farmer,St Isidore the Farmer
+St. James the Greater,St Jacques le Majeur
+St. Jane Frances Fremiot de Chantal,Ste Jeanne de Chantal
+St. Januarius,St Janvier
+St. Jerome,St Jérôme
+St. Jerome Emilian,St Jérôme Emilien
+St. Joachim,St Joachim
+St. Joan of Arc,Ste Jeanne d'Arc
+St. John,St Jean
+St. John Baptist de la Salle,St Jean Baptist de la Salle
+St. John Bosco,St Jean Bosco
+St. John Cantius,St Jean Cantius
+St. John Capistrano,St Jean Capistrano
+St. John Chrysostom,St Jean Chrysostome
+St. John Damascene,St Jean Damascene
+St. John Eudes,St Jean Eudes
+St. John Gualbert,St Jean Gualbert
+St. John Leonardi,St Jean Leonardi
+St. John Mary Vianney,St Jean-Marie Vianney
+St. John of God,St Jean de Dieu
+St. John of Matha,St Jean de Matha
+St. John of St. Facundo,St Jean de San Facundo
+St. John of the Cross,St Jean de la Croix
 St. John's Day,La Saint-Jean
-St. John's Eve,Vigile de la Fête de st Jean
-St. Josaphat,st Josaphat
-St. Joseph,st Joseph
-St. Joseph Calasanctius,st Joseph Calasanz
-St. Joseph of Cupertino,st Joseph de Cupertino
-St. Joseph the Worker,"st Joseph, artisan"
-St. Juliana Falconieri,ste Julienne Falconieri
-St. Justin,st Justin
-St. Lawrence,st Laurent
-St. Lawrence Justinian,st Laurent Justinien
-St. Lawrence of Brindisi,st Laurent de Brindisi
-St. Louis,st Louis
-St. Lucy,ste Lucie
-St. Luke,st Luc
-St. Margaret,ste Marguerite
-St. Margaret Mary Alacoque,ste Marguerite-Marie Alacoque
-St. Mark,st Marc
-St. Mark's Eve,st Mark's Eve
-St. Martha,ste Marthe
-St. Martina,ste Martine
-St. Mary Magdalen,st Mary Magdalen
-St. Mary Magdalen of Pazzi,ste Marie-Madeleine de Pazzi
-St. Mary of Egypt,ste Marie l'Égyptienne
-St. Matthew,st Matthieu
-St. Matthias,st Matthias
-St. Monica,ste Monique
-St. Nicholas,st Nicolas
-St. Nicholas of Tolentino,st Nicolas de Tolentino
-St. Norbert,st Norbert
-St. Pantaleon,st Pantaléon
-St. Pascal Baylon,st Pascal Baylon
-St. Patrick,st Patrice
-St. Paul,st Paul
-St. Paul of the Cross,st Paul de la Croix
-St. Paul the Hermit,st Paul l'Anachorète
-St. Paulinus,st Paulin
-St. Peter Canisius,st Pierre Canisius
-St. Peter Chrysologus,st Pierre Chrysologus
-St. Peter Damian,st Pierre Damian
-St. Peter Nolasco,st Pierre Nolasco
-St. Peter of Alcántara,st Pierre d'Alcantara
-St. Peter of Verona,st Pierre de Vérone
-St. Peter's Chair,st Pierre's Chair
-St. Philip Benizi,st Philippe Benizi
-St. Philip Neri,st Philip Neri
-St. Pio of Pietrelcina,st Padre Pio de Pietrelcina
-St. Placid,st Placid
-St. Polycarp,st Polycarpe
-St. Praxedes,ste Praxède
-St. Prisca,st Prisca
-St. Raphael,st Raphaël
-St. Raymond Nonnatus,st Raymond Nonnat
-St. Raymond of Peñafort,st Raymond de Peñafort
-St. Remigius,st Remi
-St. Rita of Cascia,ste Rita de Cascia
-St. Robert Bellarmine,st Robert Bellarmin
-St. Roch,st Roch
-St. Romuald,st Romuald
-St. Rosalia,ste Rosalie
-St. Rose of Lima,ste Rose de Lima
-St. Sabbas,st Sabbas
-St. Saturninus,st Sernin
-St. Scholastica,ste Scholastique
-St. Simeon,st Siméon
-St. Stanislaus,st Stanislas
-St. Stephen,st Étienne
-St. Stephen I,st Étienne I
-St. Sylvester,st Sylvestre
-St. Teresa of Avila,ste Thérèse d'Avila
-St. Theresa of Lisieux,ste Thérèse de l'Enfant-Jésus
-St. Thomas,st Thomas
-St. Thomas Aquinas,st Thomas d'Aquin
-St. Thomas Becket,st Thomas Becket
-St. Thomas More,st Thomas More
-St. Thomas of Villanova,st Thomas de Villeneuve
-St. Tiburtius & St. Susanna,st Tiburtius et st Susanna
-St. Timothy,st Timothée
-St. Titus,st Tite
-St. Ubald,st Ubald
-St. Valentine,st Valentine
-St. Venantius,st Venant de Camerino
-St. Veronica,ste Véronique
-St. Vincent Ferrer,st Vincent Ferrer
-St. Vincent de Paul,st Vincent de Paul
-St. Walpurga,st Walpurga
-St. Wenceslaus,st Venceslas
-St. William,st Guillaume
+St. John's Eve,Vigile de la Fête de St Jean
+St. Josaphat,St Josaphat
+St. Joseph,St Joseph
+St. Joseph Calasanctius,St Joseph Calasanz
+St. Joseph of Cupertino,St Joseph de Cupertino
+St. Joseph the Worker,"St Joseph, artisan"
+St. Juliana Falconieri,Ste Julienne Falconieri
+St. Justin,St Justin
+St. Lawrence,St Laurent
+St. Lawrence Justinian,St Laurent Justinien
+St. Lawrence of Brindisi,St Laurent de Brindisi
+St. Louis,St Louis
+St. Lucy,Ste Lucie
+St. Luke,St Luc
+St. Margaret,Ste Marguerite
+St. Margaret Mary Alacoque,Ste Marguerite-Marie Alacoque
+St. Mark,St Marc
+St. Mark's Eve,St Mark's Eve
+St. Martha,Ste Marthe
+St. Martina,Ste Martine
+St. Mary Magdalen,St Mary Magdalen
+St. Mary Magdalen of Pazzi,Ste Marie-Madeleine de Pazzi
+St. Mary of Egypt,Ste Marie l'Égyptienne
+St. Matthew,St Matthieu
+St. Matthias,St Matthias
+St. Monica,Ste Monique
+St. Nicholas,St Nicolas
+St. Nicholas of Tolentino,St Nicolas de Tolentino
+St. Norbert,St Norbert
+St. Pantaleon,St Pantaléon
+St. Pascal Baylon,St Pascal Baylon
+St. Patrick,St Patrice
+St. Paul,St Paul
+St. Paul of the Cross,St Paul de la Croix
+St. Paul the Hermit,St Paul l'Anachorète
+St. Paulinus,St Paulin
+St. Peter Canisius,St Pierre Canisius
+St. Peter Chrysologus,St Pierre Chrysologus
+St. Peter Damian,St Pierre Damian
+St. Peter Nolasco,St Pierre Nolasco
+St. Peter of Alcántara,St Pierre d'Alcantara
+St. Peter of Verona,St Pierre de Vérone
+St. Peter's Chair,St Pierre's Chair
+St. Philip Benizi,St Philippe Benizi
+St. Philip Neri,St Philip Neri
+St. Pio of Pietrelcina,St Padre Pio de Pietrelcina
+St. Placid,St Placid
+St. Polycarp,St Polycarpe
+St. Praxedes,Ste Praxède
+St. Prisca,St Prisca
+St. Raphael,St Raphaël
+St. Raymond Nonnatus,St Raymond Nonnat
+St. Raymond of Peñafort,St Raymond de Peñafort
+St. Remigius,St Remi
+St. Rita of Cascia,Ste Rita de Cascia
+St. Robert Bellarmine,St Robert Bellarmin
+St. Roch,St Roch
+St. Romuald,St Romuald
+St. Rosalia,Ste Rosalie
+St. Rose of Lima,Ste Rose de Lima
+St. Sabbas,St Sabbas
+St. Saturninus,St Sernin
+St. Scholastica,Ste Scholastique
+St. Simeon,St Siméon
+St. Stanislaus,St Stanislas
+St. Stephen,St Étienne
+St. Stephen I,St Étienne I
+St. Sylvester,St Sylvestre
+St. Teresa of Avila,Ste Thérèse d'Avila
+St. Theresa of Lisieux,Ste Thérèse de l'Enfant-Jésus
+St. Thomas,St Thomas
+St. Thomas Aquinas,St Thomas d'Aquin
+St. Thomas Becket,St Thomas Becket
+St. Thomas More,St Thomas More
+St. Thomas of Villanova,St Thomas de Villeneuve
+St. Tiburtius & St. Susanna,St Tiburtius et St Susanna
+St. Timothy,St Timothée
+St. Titus,St Tite
+St. Ubald,St Ubald
+St. Valentine,St Valentine
+St. Venantius,St Venant de Camerino
+St. Veronica,Ste Véronique
+St. Vincent Ferrer,St Vincent Ferrer
+St. Vincent de Paul,St Vincent de Paul
+St. Walpurga,St Walpurga
+St. Wenceslaus,St Venceslas
+St. William,St Guillaume
 Sunday within the Octave of Christmas,Dimanche dans l'Octave de Noël
 The Annunciation,L'Annonciation
 The Apparition at Lourdes,L'Apparition de l'Immaculée
 The Assumption,L'Assomption
-The Beheading of John the Baptist,Décollation de st Jean-Baptiste
+The Beheading of John the Baptist,Décollation de St Jean-Baptiste
 The Circumcision,La Circoncision
 The Forty Martyrs,Les Quarante Martyrs
 The Four Crowned Holy Martyrs,Les Quatre saints Couronnés
@@ -357,10 +357,10 @@ The Presentation of Mary,La Présentation de Marie au Temple
 The Purification,La Purification
 The Queenship of Mary,La Royauté de la B.V.M.
 The Sacred Heart,Le Sacré-Cœur de Jésus
-The Seven Holy Brothers and SS. Rufina and Secunda,Les Sept saints Frères et les stes Rufine et Seconde
+The Seven Holy Brothers and SS. Rufina and Secunda,Les Sept saints Frères et les Stes Rufine et Seconde
 The Seven Holy Founders of the Servite Order,Les Sept saints Fondateurs de l'Ordre des Servites
 The Seven Sorrows,Les Sept Douleurs de la B.V.M.
-The Stigmata of St. Francis,Les Stigmates de st François
+The Stigmata of St. Francis,Les Stigmates de St François
 The Supplica (Our Lady of Pompeii),La Supplique à Notre-Dame de Pompéi
 The Transfiguration,La Transfiguration
 The Visitation,La Visitation
@@ -370,8 +370,8 @@ Trinity Sunday,Dimanche de la sainte Trinité
 Tuesday of Holy Week,Mardi saint
 Twelfth Night,La Nuit des Rois
 Vigil of Pentecost,Vigile de la Pentecôte
-Vigil of SS. Peter & Paul,Vigile de sts Pierre et Paul
-Vigil of St. Lawrence,Vigile de st Laurent
+Vigil of SS. Peter & Paul,Vigile de Sts Pierre et Paul
+Vigil of St. Lawrence,Vigile de St Laurent
 Vigil of the Assumption,Vigile de l'Assomption
 Walpurgisnacht,Walpurgisnacht
 Whit Embertide,Whit Embertide
@@ -429,61 +429,61 @@ Lenten Embertide,Quatre-Temps de Carême
 Advent Embertide,Quatre-Temps de l'Avent
 Whit Embertide,Quatre-Temps de la Pentecôte
 September Embertide,Quatre-Temps de Septembre
-St. Peter,st Pierre
-St. Bernadette,ste Bernadette
-St. Gregory the Great,st Grégoire le Grand
-St. John the Baptist,st Jean-Baptiste
-St. Mary Magdalene,ste Marie-Madeleine
-St. Pius X,st Pie X
-St. Michael the Archangel,st Michel Archange
-St. Therese of the Child Jesus,ste Thérèse de l'Enfant-Jésus
-St. Raphael the Archangel,st Raphaël Archange
-St. Martin of Tours,st Martin de Tours
-St. Clement I,st Clément Ier
-St. John the Evangelist,st Jean l'Évangéliste
-St. Sylvester I,"st Sylvestre Ier"
-St Raymond of Peñafort,st Raymond de Peñafort
-St John of Matha,st Jean de Matha
-St Cyril of Alexandria,st Cyrille d'Alexandrie
-St Peter Damien,st Pierre Damien
-St Mary of Egypt,ste Marie l'Égyptienne
-St Fidelis of Sigmaringen,st Fidèle de Sigmaringen
-St Joseph the Worker,"st Joseph, artisan"
-St Bernardine of Siena,st Bernardin de Sienne
+St. Peter,St Pierre
+St. Bernadette,Ste Bernadette
+St. Gregory the Great,St Grégoire le Grand
+St. John the Baptist,St Jean-Baptiste
+St. Mary Magdalene,Ste Marie-Madeleine
+St. Pius X,St Pie X
+St. Michael the Archangel,St Michel Archange
+St. Therese of the Child Jesus,Ste Thérèse de l'Enfant-Jésus
+St. Raphael the Archangel,St Raphaël Archange
+St. Martin of Tours,St Martin de Tours
+St. Clement I,St Clément Ier
+St. John the Evangelist,St Jean l'Évangéliste
+St. Sylvester I,"St Sylvestre Ier"
+St Raymond of Peñafort,St Raymond de Peñafort
+St John of Matha,St Jean de Matha
+St Cyril of Alexandria,St Cyrille d'Alexandrie
+St Peter Damien,St Pierre Damien
+St Mary of Egypt,Ste Marie l'Égyptienne
+St Fidelis of Sigmaringen,St Fidèle de Sigmaringen
+St Joseph the Worker,"St Joseph, artisan"
+St Bernardine of Siena,St Bernardin de Sienne
 Pentecost Wednesday,Mercredi de la Pentecôte
 Pentecost Thursday,Jeudi de la Pentecôte
 Pentecost Friday,Vendredi de la Pentecôte
 Pentecost Saturday,Samedi de la Pentecôte
-St Basil the Great,st Basile le Grand
-St Henry,st Henri
-The Seven Holy Brothers and Sts Rufina and Secunda,Les Sept saints Frères et les stes Rufine et Seconde
-St Rose of Lima,ste Rose de Lima
-St Veronica,ste Véronique
+St Basil the Great,St Basile le Grand
+St Henry,St Henri
+The Seven Holy Brothers and Sts Rufina and Secunda,Les Sept saints Frères et les Stes Rufine et Seconde
+St Rose of Lima,Ste Rose de Lima
+St Veronica,Ste Véronique
 Canadian martyrs,Les martyrs canadiens
-St Theresa of Lisieux,ste Thérèse de l'Enfant-Jésus
-St Peter of Alcántara,st Pierre d'Alcántara
+St Theresa of Lisieux,Ste Thérèse de l'Enfant-Jésus
+St Peter of Alcántara,St Pierre d'Alcántara
 Nativity of Mary,Nativité de Marie
-Gerard Majella,st Gérard Majella
+Gerard Majella,St Gérard Majella
 St Albert the Great,Albert le Grand
-St Elizabeth of Hungary,ste Élisabeth de Hongrie
-St Felix of Valois,st Félix de Valois
-St John of the Cross,st Jean de la Croix
+St Elizabeth of Hungary,Ste Élisabeth de Hongrie
+St Felix of Valois,St Félix de Valois
+St John of the Cross,St Jean de la Croix
 Rogate Sunday,Cinquième dimanche de Pâques
-Sts. Cletus and Marcellinus,sts Clet et Marcellin
-Sts. Perpetua and Felicitas,stes Perpétue et Félicité
-St. John of Capistrano,st Jean de Capistran
-St. Peter in Chains,st Pierre aux Liens
-St. John Maria Vianney,st Jean-Marie Vianney
-St. Peter Claver,st Pierre Claver
-St. John of Kanti,st Jean de Kenty
-St. Jane Frances de Chantal,ste Jeanne de Chantal
-St. Peter of Alcantara,st Pierre d'Alcantara
-Sts. Cyril and Methodius,sts Cyrille et Méthode
-The Seven Holy Brothers and Sts. Rufina and Secunda,Les Sept saints Frères et les stes Rufine et Seconde
-St. Jean's Eve,Vigile de la Fête de st Jean
-"SS. Vitus, Modestus & Crescentia","sts Vite, Modeste, et Crescence"
+Sts. Cletus and Marcellinus,Sts Clet et Marcellin
+Sts. Perpetua and Felicitas,Stes Perpétue et Félicité
+St. John of Capistrano,St Jean de Capistran
+St. Peter in Chains,St Pierre aux Liens
+St. John Maria Vianney,St Jean-Marie Vianney
+St. Peter Claver,St Pierre Claver
+St. John of Kanti,St Jean de Kenty
+St. Jane Frances de Chantal,Ste Jeanne de Chantal
+St. Peter of Alcantara,St Pierre d'Alcantara
+Sts. Cyril and Methodius,Sts Cyrille et Méthode
+The Seven Holy Brothers and Sts. Rufina and Secunda,Les Sept saints Frères et les Stes Rufine et Seconde
+St. Jean's Eve,Vigile de la Fête de St Jean
+"SS. Vitus, Modestus & Crescentia","Sts Vite, Modeste, et Crescence"
 SS. Gervasius & Protasius,Gervais et Protais
-"SS. Nazarius, Celsus, Victor I & Innocent I","sts Nazaire et Celse, Victor Ier, Innocent Ier"
-SS. Tiburtius & Susanna,st Tiburce et ste Suzanne
-St. Placidus,st Placide
-St. Francis Borgia,st François Borgia
+"SS. Nazarius, Celsus, Victor I & Innocent I","Sts Nazaire et Celse, Victor Ier, Innocent Ier"
+SS. Tiburtius & Susanna,St Tiburce et Ste Suzanne
+St. Placidus,St Placide
+St. Francis Borgia,St François Borgia

--- a/tridentine_calendar/i18n/translator.py
+++ b/tridentine_calendar/i18n/translator.py
@@ -253,7 +253,7 @@ class Translator:
     def _is_plural(self, name):
         if self.lang != 'fr':
             return False
-        plural_prefixes = ('Les ', 'les ', 'sts ', 'stes ')
+        plural_prefixes = ('Les ', 'les ', 'Sts ', 'Stes ', 'sts ', 'stes ')
         return name.lstrip('» ').lstrip('› ').startswith(plural_prefixes)
 
     def get_ordinal(self, n):

--- a/tridentine_calendar/tests/test_fr_localization.py
+++ b/tridentine_calendar/tests/test_fr_localization.py
@@ -16,7 +16,7 @@ def test_fr_feast_full_name():
     translator = Translator(lang='fr')
     # Normal feast
     assert translator.format_feast_full_name(
-        'St. Hilary', 3) == 'la fête de st Hilaire'
+        'St. Hilary', 3) == 'la fête de St Hilaire'
     # Elision (handled by L'Annonciation in CSV)
     assert translator.format_feast_full_name(
         'The Annunciation', 1) == 'L\'Annonciation'
@@ -25,7 +25,7 @@ def test_fr_feast_full_name():
         'The Circumcision', 1) == 'La Circoncision'
     # Commemoration
     assert translator.format_feast_full_name(
-        'St. Hilary', 4) == 'la commémoraison de st Hilaire'
+        'St. Hilary', 4) == 'la commémoraison de St Hilaire'
 
 
 def test_fr_class_feria():
@@ -61,11 +61,11 @@ def test_fr_plural_agreement():
     assert "sont" in translator.format_class_feria("Les martyrs", 2, True)
     assert "n'ont pas" in translator.format_no_special_liturgy("Les Grandes Ô")
 
-    # Test "sts"
-    assert "sont" in translator.format_class_feria("sts Abdon et Sennen", 3, True)
+    # Test "Sts"
+    assert "sont" in translator.format_class_feria("Sts Abdon et Sennen", 3, True)
 
-    # Test "stes"
-    assert "sont" in translator.format_class_feria("stes Perpétue et Félicité", 3, True)
+    # Test "Stes"
+    assert "sont" in translator.format_class_feria("Stes Perpétue et Félicité", 3, True)
 
     # Test outranking plural
     outranking = translator.format_outranking("Les martyrs", "Une fête", True)

--- a/tridentine_calendar/tests/test_issue_pape_redundancy.py
+++ b/tridentine_calendar/tests/test_issue_pape_redundancy.py
@@ -8,11 +8,11 @@ def test_fr_pape_redundancy():
     name = "Pope Melchiades"
     titles = ["Pope", "Martyr"]
     full_name = translator.format_feast_full_name(name, 3, titles)
-    # The current (buggy) output is "la fête de st Miltiade, pape (pape, martyr)"
-    # The expected output is "la fête de st Miltiade (pape, martyr)"
+    # The current (buggy) output is "la fête de St Miltiade, pape (pape, martyr)"
+    # The expected output is "la fête de St Miltiade (pape, martyr)"
     assert "pape (" in full_name or not full_name.endswith(", pape")
     assert ", pape (" not in full_name
-    assert full_name == "la fête de st Miltiade (pape, martyr)"
+    assert full_name == "la fête de St Miltiade (pape, martyr)"
 
 
 def test_fr_papes_redundancy():
@@ -21,7 +21,7 @@ def test_fr_papes_redundancy():
     name = "SS. Soter & Caius"
     titles = ["Pope", "Martyr"]
     full_name = translator.format_feast_full_name(name, 3, titles)
-    # Current: "la fête de sts Sôter et Caïus, papes (pape, martyr)"
-    # Expected: "la fête de sts Sôter et Caïus (pape, martyr)"
+    # Current: "la fête de Sts Sôter et Caïus, papes (pape, martyr)"
+    # Expected: "la fête de Sts Sôter et Caïus (pape, martyr)"
     assert ", papes (" not in full_name
-    assert full_name == "la fête de sts Sôter et Caïus (pape, martyr)"
+    assert full_name == "la fête de Sts Sôter et Caïus (pape, martyr)"

--- a/tridentine_calendar/tests/test_tridentine_calendar.py
+++ b/tridentine_calendar/tests/test_tridentine_calendar.py
@@ -411,7 +411,7 @@ class TestLiturgicalCalendar(unittest.TestCase):
         desc_fr = event_fr.generate_description()
         # Verify capitalization and placement.
         self.assertIn(
-            'La fête de st Bonaventure (évêque, confesseur, docteur de '
+            'La fête de St Bonaventure (évêque, confesseur, docteur de '
             'l\'Église) est une fête de III',
             desc_fr
         )
@@ -422,7 +422,7 @@ class TestLiturgicalCalendar(unittest.TestCase):
         ]
         desc_fr_with_urls = event_fr.generate_description()
         self.assertIn(
-            "Plus d'informations sur la fête de st Bonaventure :",
+            "Plus d'informations sur la fête de St Bonaventure :",
             desc_fr_with_urls
         )
         self.assertNotIn(


### PR DESCRIPTION
This change capitalizes the abbreviations "st", "ste", "sts", and "stes" in the French translation file and updates the pluralization heuristic in the `Translator` class to ensure correct grammatical agreement with the new capitalized prefixes. All related tests have been updated to assert the capitalized versions.

---
*PR created automatically by Jules for task [3869466881283039470](https://jules.google.com/task/3869466881283039470) started by @joe-antognini*