### PR TITLE
Capitalize French event summaries in ICS output

### DIFF
--- a/tridentine_calendar/tridentine_calendar.py
+++ b/tridentine_calendar/tridentine_calendar.py
@@ -783,6 +783,8 @@ class LiturgicalYear:
         for date in iterate_liturgical_year(self.year):
             for i, elem in enumerate(self.calendar[date]):
                 ics_name = self.translator.translate(elem.name)
+                if self.lang == 'fr' and ics_name:
+                    ics_name = ics_name[0].upper() + ics_name[1:]
                 description = ''
 
                 if i > 0 and elem.liturgical_event and not elem.addition:


### PR DESCRIPTION
Fixed an issue where French liturgical event summaries in the ICS output were not capitalized correctly. I modified `tridentine_calendar/tridentine_calendar.py` to ensure that when the language is set to French, the first letter of the translated event name is capitalized before being used as the ICS summary. This fix specifically targets the summary field while leaving the already correct description field untouched. Verified with a test script and ran the full test suite.

---
*PR created automatically by Jules for task [5873736074927190723](https://jules.google.com/task/5873736074927190723) started by @joe-antognini*